### PR TITLE
Add support for :backend parameter in define_authentication_tasks and define_project_tasks

### DIFF
--- a/lib/rake_fly/task_sets/authentication.rb
+++ b/lib/rake_fly/task_sets/authentication.rb
@@ -13,6 +13,8 @@ module RakeFly
       parameter :target, required: true
       parameter :concourse_url, required: true
       parameter :team, default: 'main'
+
+      parameter :backend, default: RakeFly::Tasks::Authentication::Login::ApiBackend
       parameter :username
       parameter :password
 

--- a/lib/rake_fly/task_sets/project.rb
+++ b/lib/rake_fly/task_sets/project.rb
@@ -16,6 +16,8 @@ module RakeFly
 
       parameter :concourse_url, required: true
       parameter :team, default: 'main'
+
+      parameter :backend, default: RakeFly::Tasks::Authentication::Login::ApiBackend
       parameter :username
       parameter :password
 

--- a/spec/rake_fly/task_sets/authentication_spec.rb
+++ b/spec/rake_fly/task_sets/authentication_spec.rb
@@ -92,6 +92,39 @@ describe RakeFly::TaskSets::Authentication do
       expect(rake_task.creator.team).to(eq('main'))
     end
 
+    it 'uses the default backend when not supplied' do
+      target = 'supercorp-ci'
+      concourse_url = "https://concourse.example.com"
+      backend = RakeFly::Tasks::Authentication::Login::ApiBackend
+
+      namespace :authentication do
+        subject.define(
+          target: target,
+          concourse_url: concourse_url)
+      end
+
+      rake_task = Rake::Task["authentication:login"]
+
+      expect(rake_task.creator.backend).to(eq(backend))
+    end
+
+    it 'uses the provided backend when supplied' do
+      target = 'supercorp-ci'
+      concourse_url = "https://concourse.example.com"
+      backend = RakeFly::Tasks::Authentication::Login::FlyBackend
+
+      namespace :authentication do
+        subject.define(
+          target: target,
+          concourse_url: concourse_url,
+          backend: backend)
+      end
+
+      rake_task = Rake::Task["authentication:login"]
+
+      expect(rake_task.creator.backend).to(eq(backend))
+    end
+
     it 'uses the provided team when supplied' do
       target = 'supercorp-ci'
       concourse_url = "https://concourse.example.com"

--- a/spec/rake_fly/task_sets/project_spec.rb
+++ b/spec/rake_fly/task_sets/project_spec.rb
@@ -161,6 +161,31 @@ describe RakeFly::TaskSets::Project do
         expect(rake_task.creator.team).to(eq(team))
       end
 
+      it 'uses the default backend when not supplied' do
+        concourse_url = "https://concourse.example.com"
+        backend = RakeFly::Tasks::Authentication::Login::ApiBackend
+
+        define_tasks(
+          concourse_url: concourse_url)
+
+        rake_task = Rake::Task["authentication:login"]
+
+        expect(rake_task.creator.backend).to(eq(backend))
+      end
+
+      it 'uses the provided backend when supplied' do
+        concourse_url = "https://concourse.example.com"
+        backend = RakeFly::Tasks::Authentication::Login::FlyBackend
+
+        define_tasks(
+          concourse_url: concourse_url,
+          backend: backend)
+
+        rake_task = Rake::Task["authentication:login"]
+
+        expect(rake_task.creator.backend).to(eq(backend))
+      end
+
       it 'has no username by default' do
         concourse_url = "https://concourse.example.com"
 


### PR DESCRIPTION
This PR adds support for the :backend parameter in define_authentication_tasks and define_project_tasks
My rake knowledge isn't so great, so I duplicated the default that's in login.rb into authentication.rb, if you know a better way to do this let me know and I'll make the change